### PR TITLE
udpates to LANL processing script, including simplified function para…

### DIFF
--- a/data-raw/LANL/LANL-processing-script.R
+++ b/data-raw/LANL/LANL-processing-script.R
@@ -11,6 +11,9 @@ lanl_filenames <- list.files(".", pattern=".csv", full.names=FALSE)
 dates <- unlist(lapply(lanl_filenames, FUN = function(x) substr(basename(x), 0, 10)))
 most_recent_date <- max(as.Date(dates))
 
+## LANL forecasts are typically available the day after the date in the filename
+forecast_date <- most_recent_date + 1
+
 cum_filename <- paste0(most_recent_date, "_deaths_quantiles_us_website.csv")
 inc_filename <- paste0(most_recent_date, "_deaths_incidence_quantiles_us_website.csv")
 
@@ -28,5 +31,5 @@ us_inc <- process_global_lanl_file(us_inc_filename)
 
 write_csv(bind_rows(cum_dat, inc_dat, us_cum, us_inc), 
           paste0("../../data-processed/LANL-GrowthRate/", 
-                          most_recent_date, 
+                          forecast_date, 
                           "-LANL-GrowthRate.csv"))

--- a/data-raw/LANL/process_lanl_file.R
+++ b/data-raw/LANL/process_lanl_file.R
@@ -7,13 +7,13 @@ source("../../code/processing-fxns/get_next_saturday.R")
 #' turn LANL forecast file into quantile-based format
 #'
 #' @param lanl_filepath path to a lanl submission file
+#' @param fips_file path to the fips codes file
 #'
 #' @details designed to process either an incidence or cumulative death forecast
 #'
 #' @return a data.frame in quantile format
 process_lanl_file <- function(lanl_filepath, 
-                              fips_file = "../../template/state_fips_codes.csv",
-                              forecast_dates_file = "../../template/covid19-death-forecast-dates.csv") {
+                              fips_file = "../../template/state_fips_codes.csv") {
     require(tidyverse)
     require(MMWRweek)
     require(lubridate)
@@ -29,7 +29,6 @@ process_lanl_file <- function(lanl_filepath,
     fips <- read_csv(fips_file)
     
     ## read in forecast dates
-    fcast_dates <- read_csv(forecast_dates_file)
     timezero <- as.Date(substr(basename(lanl_filepath), 0, 10))
     
     ## read in data
@@ -39,9 +38,8 @@ process_lanl_file <- function(lanl_filepath,
     if(forecast_date != timezero)
         stop("timezero in the filename is not equal to the forecast date in the data")
     
-    ## make USVI adjustment
-    usvi_idx <- which(dat$state=="Virgin Islands")
-    dat[usvi_idx, "state"] <- rep("U.S. Virgin Islands")
+    ## update forecast date to be day on which forecast is available, not last date of data
+    forecast_date <- forecast_date + 1
     
     ## put into long format
     dat_long <- pivot_longer(dat, cols=starts_with("q."), names_to = "q", values_to = "cum_deaths") %>%


### PR DESCRIPTION
…meters, and relevant to #244, changing the way that forecast date is calculated to always be one day after the forecast date in the filenames (because LANL forecast date corresponds to the date of last data available, not date forecast was run).

also, adding 2020-05-07 processed data.

And fixing references to Virgin Islands in FIPS data based on recent changes to that file.