### PR TITLE
Forecast with new model as of 2020-05-25 (2nd attempt)

### DIFF
--- a/data-processed/UT-Mobility/metadata-UT-Mobility.txt
+++ b/data-processed/UT-Mobility/metadata-UT-Mobility.txt
@@ -21,20 +21,17 @@ Data_format: Posterior quantiles,
 forecast_startdate: 2020-05-11
 forecast_frequency: daily
 
-data_inputs_known: observed death rates, anonymized mobile-phone GPS
-traces aggregated at the state level
+data_source_known:  >-
+    observed death rates, anonymized mobile-phone GPS traces aggregated at the state level
+    JHU CSSE https://github.com/CSSEGISandData/COVID-19; SafeGraph https://docs.safegraph.com/docs/social-distancing-metrics
 
-data_source_known: JHU CSSE <https://github.com/CSSEGISandData/COVID-19>; SafeGraph <https://docs.safegraph.com/docs/social-distancing-metrics>
-
-this_model_is_an_ensemble: FALSE
-this_model_is_unconditional: FALSE
+this_model_is_an_ensemble: false
+this_model_is_unconditional: false
 
 methods: >-
-
-This model makes predictions assuming that social distancing patterns, as measured by anonymized mobile-phone GPS traces, remain constant in the future.  However, we receive this data in real time to update forecasts on a weekly basis.  
+    NOTE: On May 7, 2020 the New York Times’ made substantial changes in how it reports COVID-19 deaths, with a large effect on data New York state in particular. We are working our way through the implications of these changes for our model. In the meantime, we are using data from Johns Hopkins University, which includes both probable and confirmed deaths, to inform our projections
+    This model makes predictions assuming that social distancing patterns, as measured by anonymized mobile-phone GPS traces, remain constant in the future.  However, we receive this data in real time to update forecasts on a weekly basis.  This model models only *first-wave deaths*.
 
 methods_long: >-
-
-For each US state, we use local data from mobile-phone GPS traces made available by [SafeGraph] to quantify the changing impact of social-distancing measures on ``flattening the curve.''  SafeGraph is a data company that aggregates anonymized location data from numerous applications in order to provide insights about physical places. To enhance privacy, SafeGraph excludes census block group information if fewer than five devices visitedan establishment in a month from a given census block group.  These data are aggregated by state to create metrics of social distancing, which are used as predictors in the model.
-
-We use an SEIR-based model, where the infection rate is allowed to vary according to social distancing behavior from SafeGraph.  We updated our model on May 25, 2020, and are currently working on a technical report of the updated model. 
+    For each US state, we use local data from mobile-phone GPS traces made available by [SafeGraph] to quantify the changing impact of social-distancing measures on ``flattening the curve.''  SafeGraph is a data company that aggregates anonymized location data from numerous applications in order to provide insights about physical places. To enhance privacy, SafeGraph excludes census block group information if fewer than five devices visitedan establishment in a month from a given census block group.  These data are aggregated by state to create metrics of social distancing, which are used as predictors in the model.
+    We use a Bayesian multilevel negative binomial regression model for the number of deaths for each day, and implement the model in R using the rstanarm package. See technical report at https://covid-19.tacc.utexas.edu/media/filer_public/87/63/87635a46-b060-4b5b-a3a5-1b31ab8e0bc6/ut_covid-19_mortality_forecasting_model_latest.pdf

--- a/data-processed/UT-Mobility/metadata-UT-Mobility.txt
+++ b/data-processed/UT-Mobility/metadata-UT-Mobility.txt
@@ -31,12 +31,10 @@ this_model_is_unconditional: FALSE
 
 methods: >-
 
-NOTE: On May 7, 2020 the New York Times’ made substantial changes in how it reports COVID-19 deaths, with a large effect on data New York state in particular. We are working our way through the implications of these changes for our model. In the meantime, we are using data from Johns Hopkins University, which includes both probable and confirmed deaths, to inform our projections
-
-This model makes predictions assuming that social distancing patterns, as measured by anonymized mobile-phone GPS traces, remain constant in the future.  However, we receive this data in real time to update forecasts on a weekly basis.  This model models only *first-wave deaths*.
+This model makes predictions assuming that social distancing patterns, as measured by anonymized mobile-phone GPS traces, remain constant in the future.  However, we receive this data in real time to update forecasts on a weekly basis.  
 
 methods_long: >-
 
 For each US state, we use local data from mobile-phone GPS traces made available by [SafeGraph] to quantify the changing impact of social-distancing measures on ``flattening the curve.''  SafeGraph is a data company that aggregates anonymized location data from numerous applications in order to provide insights about physical places. To enhance privacy, SafeGraph excludes census block group information if fewer than five devices visitedan establishment in a month from a given census block group.  These data are aggregated by state to create metrics of social distancing, which are used as predictors in the model.
 
-We use a Bayesian multilevel negative binomial regression model for the number of deaths for each day, and implement the model in R using the rstanarm package. See technical report at https://covid-19.tacc.utexas.edu/media/filer_public/87/63/87635a46-b060-4b5b-a3a5-1b31ab8e0bc6/ut_covid-19_mortality_forecasting_model_latest.pdf
+We use an SEIR-based model, where the infection rate is allowed to vary according to social distancing behavior from SafeGraph.  We updated our model on May 25, 2020, and are currently working on a technical report of the updated model. 


### PR DESCRIPTION
@nickreich This is second try at updating our forecast for 2020-05-25 (see #375)

I know there's a conflict with the metadata, but I only updated it to reflect changes to our model. The current version of our metadata on the main repo should be replaced as it is not up to date anymore. 