### PR TITLE
Update node to 10.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - sudo apt-get update
   
 node_js:
-  - 7
+  - 10.2
 
 cache:
   directories: $TRAVIS_BUILD_DIR/packrat/


### PR DESCRIPTION
This is a test PR to bump up the node version to `10.2`. I have been personally using this version for local builds and deployment and it works fine. hence, it should also be updated here.