### PR TITLE
Fixing broken locations link in data-processed README

### DIFF
--- a/data-processed/README.md
+++ b/data-processed/README.md
@@ -234,7 +234,7 @@ week time period.
 ### `location`
 
 Values in the `location` column must be one of the "locations" in this
-[FIPS numeric code file](./data-locations/locations.csv) which includes 
+[FIPS numeric code file](../data-locations/locations.csv) which includes 
 numeric FIPS codes for U.S. states, counties, territories, and districts as
 well as "US" for national forecasts. 
 


### PR DESCRIPTION
## Fix broken link in `data-processed` README file.

The link the the `locations.csv` file in the README was pointing to the wrong location (needs to go up a directory).

## Checklist

- [x] Specify a proper PR title with your team name.
- [x] All validation checks ran successfully on your branch. Instructions to run the tests locally is present [here](https://github.com/reichlab/covid19-forecast-hub/wiki/Running-Checks-Locally).
