### PR TITLE
Use model_abbr instead of model_name for model identification

### DIFF
--- a/code/zoltar_scripts/upload_covid19_forecasts_to_zoltar.py
+++ b/code/zoltar_scripts/upload_covid19_forecasts_to_zoltar.py
@@ -191,9 +191,9 @@ def upload_covid_all_forecasts(path_to_processed_model_forecasts, dir_name):
                     return error_from_transformation
                 else:
                     try:
-                        logger.debug('Upload forecast for model: %s \t|\t File: %s\n' % (metadata['model_name'],forecast))
+                        logger.debug('Upload forecast for model: %s \t|\t File: %s\n' % (metadata['model_abbr'],forecast))
                         util.upload_forecast(conn, quantile_json, forecast,
-                                             project_name, metadata['model_name'], time_zero_date,
+                                             project_name, metadata['model_abbr'], time_zero_date,
                                              overwrite=over_write)
                         db[forecast] = checksum
                     except Exception as ex:

--- a/visualization/requirements.txt
+++ b/visualization/requirements.txt
@@ -6,5 +6,6 @@ urllib3
 selenium
 webdriver-manager
 pyyaml
+pprint
 git+https://github.com/reichlab/zoltpy/
 https://github.com/hannanabdul55/pykwalify/archive/master.zip


### PR DESCRIPTION
## Description

Use `model_abbr` instead of `model_name` for model identification when uploading to zoltar. 

Related PR in zoltpy: https://github.com/reichlab/zoltpy/pull/36 