### PR TITLE
Update wk-ahead from 4 to 20 in zoltar truth data creation

### DIFF
--- a/data-truth/zoltar-truth-data.py
+++ b/data-truth/zoltar-truth-data.py
@@ -95,7 +95,7 @@ def configure_JHU_data(df, target):
     df_truth_values = df_truth_long[df_truth_long['day'] == 7]
 
     # find week-ahead targets
-    for i in range(4):
+    for i in range(20):
         weeks_ahead = i + 1  # add one to [0,3]
         days_back = 5 + ((weeks_ahead - 1) * 7)  # timezero is on Mondays
 


### PR DESCRIPTION
## What's there in this PR?
- Update the Zoltar truth script to use a longer horizon (max of 20 wk ahead instead of the previous max of 4 wk ahead)