### PR TITLE
Include only models that have inc/cum targets

### DIFF
--- a/visualization/scripts/convert_forecasts.py
+++ b/visualization/scripts/convert_forecasts.py
@@ -3,6 +3,7 @@ import glob
 import os
 from utils import _utils
 from pathlib import Path
+import shutil
 
 def reformat_forecasts(file_path, target, root, data):
     # read forecast
@@ -78,8 +79,22 @@ data = _utils.get_data()
 print(root, data)
 # loop through model directories
 my_path = Path("./data/")
+to_be_deleted= []
 for file_path in my_path.glob("**/**/*.csv"):
     target = os.path.basename(os.path.dirname(os.path.dirname(file_path)))
     print(file_path)
     df2 = reformat_forecasts(file_path, target, root, data)
-    df2.to_csv(file_path, index=False, float_format='%.14f')
+    if df2.size > 0:
+        df2.to_csv(file_path, index=False, float_format='%.14f')
+    else:
+        # Remove file as it has no data! 
+        file_path.unlink()
+
+model_dirs = list(my_path.glob("**/**/*.yml"))
+for file_path in model_dirs:
+    if len(list((file_path / '..').resolve().glob('*.csv'))) ==0:
+        # empty list delete directory
+        shutil.rmtree((file_path / '..').resolve())
+        print(f"Deleted {(file_path / '..').resolve()!r}")
+    
+

--- a/visualization/scripts/parse-data.js
+++ b/visualization/scripts/parse-data.js
@@ -71,7 +71,7 @@ modelDirs.forEach(modelDir => {
       models.getModelCsvs(modelDir)
       .forEach(csvFile => {
         let info = parseCSVInfo(path.basename(csvFile))
-        
+
         // CSV target path
         let csvTargetDir = path.join('./data', target_cats, modelId)
         fs.ensureDirSync(csvTargetDir)

--- a/visualization/scripts/parse-data.js
+++ b/visualization/scripts/parse-data.js
@@ -57,7 +57,6 @@ let modelDirs = models.getModelDirs(
   '../data-processed',
   ['component-models']
 )
-
 modelDirs.forEach(modelDir => {
   // Read metadata and parse to usable form
   let rootMeta = models.getModelMetadata(modelDir)
@@ -71,7 +70,6 @@ modelDirs.forEach(modelDir => {
       models.getModelCsvs(modelDir)
       .forEach(csvFile => {
         let info = parseCSVInfo(path.basename(csvFile))
-
         // CSV target path
         let csvTargetDir = path.join('./data', target_cats, modelId)
         fs.ensureDirSync(csvTargetDir)

--- a/visualization/scripts/parse-data.js
+++ b/visualization/scripts/parse-data.js
@@ -57,6 +57,7 @@ let modelDirs = models.getModelDirs(
   '../data-processed',
   ['component-models']
 )
+
 modelDirs.forEach(modelDir => {
   // Read metadata and parse to usable form
   let rootMeta = models.getModelMetadata(modelDir)

--- a/visualization/scripts/parse-data.js
+++ b/visualization/scripts/parse-data.js
@@ -71,6 +71,7 @@ modelDirs.forEach(modelDir => {
       models.getModelCsvs(modelDir)
       .forEach(csvFile => {
         let info = parseCSVInfo(path.basename(csvFile))
+        
         // CSV target path
         let csvTargetDir = path.join('./data', target_cats, modelId)
         fs.ensureDirSync(csvTargetDir)


### PR DESCRIPTION
## Description

Include only those models in visualization that have inc/cum targets in their forecasts. 

## Method
- After converting forecasts (`convert_forecast.py`), add a check to see if the _filtered_ DataFrame has at least one row, otherwise, delete the file. 
- Then parse through all models in all targets and remove folders that have no forecast files. 

Closes #1234 