### PR TITLE
Codes to update truth weekly

### DIFF
--- a/.github/workflows/update_truth_weekly.yml
+++ b/.github/workflows/update_truth_weekly.yml
@@ -1,0 +1,34 @@
+name: Update JHU, NY Times, USAFacts truth data weekly
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Update truth weekly'
+  schedule:
+    - cron: '0 16 * * 0'
+
+jobs:
+  upload_zoltar:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.2]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
+    - run: npm install
+    - run: pip3 install -r visualization/requirements.txt
+    - run: bash travis/update_truth_weekly.sh
+      env:
+        Z_USERNAME: ${{ secrets.Z_USERNAME}}
+        Z_PASSWORD: ${{ secrets.Z_PASSWORD}}
+        GH_TOKEN: ${{secrets.GH_TOKEN}}

--- a/data-truth/nytimes/nytimes.py
+++ b/data-truth/nytimes/nytimes.py
@@ -1,0 +1,47 @@
+import pandas as pd
+import os
+
+# Global Constants
+US_URL = "https://raw.githubusercontent.com/nytimes/covid-19-data/master/us.csv"
+STATES_URL = "https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv"
+COUNTIES_URL = "https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-counties.csv"
+RELATIVE_PATH = "data-truth/nytimes"
+
+# Download raw data
+us = pd.read_csv(US_URL, dtype={'cases': int, 'deaths': int}).fillna(value = 'NA')
+us['date'] = pd.to_datetime(us['date'])
+us.to_csv(os.path.join(RELATIVE_PATH,"raw/us.csv"), index = False)
+
+states = pd.read_csv(STATES_URL, dtype={'fips': str, 'cases': int, 'deaths': int}).fillna(value = 'NA')
+states['date'] = pd.to_datetime(states['date'])
+states.to_csv(os.path.join(RELATIVE_PATH,"raw/us-states.csv"), index = False)
+
+counties = pd.read_csv(COUNTIES_URL, dtype={'fips': str, 'cases': int, 'deaths': int}).fillna(value = 'NA')
+counties['date'] = pd.to_datetime(counties['date'])
+counties.to_csv(os.path.join(RELATIVE_PATH,"raw/us-counties.csv"), index = False)
+
+# Generate truth data for: cumulative deaths, cumulative cases, incident deaths, incident cases
+us.insert(loc = 1, column = 'location', value = 'US')
+
+states.drop(columns = 'state', inplace = True)
+states.rename(columns = {'fips': 'location'}, inplace = True)
+
+counties.drop(columns = ['county', 'state'], inplace = True)
+counties.rename(columns = {'fips': 'location'}, inplace = True)
+
+main_df = pd.concat([us, states, counties])
+main_df = main_df.sort_values(['location','date'])
+
+# Output truth cumulative
+main_df.to_csv(os.path.join(RELATIVE_PATH,"truth_nytimes-Cumulative Cases.csv"), columns = ['date', 'location', 'cases'], header = ['date', 'location', 'value'], index = False)
+main_df.to_csv(os.path.join(RELATIVE_PATH,"truth_nytimes-Cumulative Deaths.csv"), columns = ['date', 'location', 'deaths'], header = ['date', 'location', 'value'], index = False)
+
+# Output truth incident
+main_df = main_df.reset_index()
+main_df['diff_cases'] = main_df.groupby(by = ['location'])['cases'].diff().fillna(main_df['cases'])
+main_df = main_df.astype({'diff_cases': int})
+main_df.to_csv(os.path.join(RELATIVE_PATH,"truth_nytimes-Incident Cases.csv"), columns = ['date', 'location', 'diff_cases'], header = ['date', 'location', 'value'], index = False)
+
+main_df['diff_deaths'] = main_df.groupby(by = ['location'])['deaths'].diff().fillna(main_df['deaths'])
+main_df = main_df.astype({'diff_deaths': int})
+main_df.to_csv(os.path.join(RELATIVE_PATH,"truth_nytimes-Incident Deaths.csv"), columns = ['date', 'location', 'diff_deaths'], header = ['date', 'location', 'value'], index = False)

--- a/data-truth/usafacts/usafacts.py
+++ b/data-truth/usafacts/usafacts.py
@@ -1,0 +1,85 @@
+import pandas as pd
+import os
+
+def reformat_county_data(df):
+    df.drop(columns = ['stateFIPS', 'County Name', 'State'], inplace = True)
+    df.rename(columns = {'countyFIPS': 'location'}, inplace = True)
+
+    # Drop row that is not county data
+    df = df[df['location']>1000]
+
+    # Format county fips code
+    df = df.astype({'location': str})
+    df['location'] = df['location'].apply(lambda x: x.zfill(5))
+
+    # Pivot the data to have each row holding the value (cases/death) per location - date pair
+    df = df.melt(id_vars = ['location'], var_name = 'date', value_name = 'value')
+    df = df[['date', 'location', 'value']]
+
+    # Format the date
+    df['date'] = pd.to_datetime(df['date'])
+    return df
+
+
+def reformat_state_data(df):
+    df.drop(columns = ['countyFIPS', 'County Name', 'State'], inplace = True)
+    df.rename(columns = {'stateFIPS': 'location'}, inplace = True)
+
+    # Format state fips code
+    df = df.astype({'location': str})
+    df['location'] = df['location'].apply(lambda x: x.zfill(2))
+
+    # Pivot the data to have each row holding the value (cases/death) per location - date pair
+    df = df.melt(id_vars = ['location'], var_name = 'date', value_name = 'value')
+    df = df[['date', 'location', 'value']]
+    
+    # Format the date
+    df['date'] = pd.to_datetime(df['date'])
+
+    # Sum up all county data within the state to get the aggregated state data
+    df = df.groupby(['date', 'location']).sum().reset_index()
+    return df
+
+# Global Constants
+CONFIRMED_URL = "https://usafactsstatic.blob.core.windows.net/public/data/covid-19/covid_confirmed_usafacts.csv"
+DEATHS_URL = "https://usafactsstatic.blob.core.windows.net/public/data/covid-19/covid_deaths_usafacts.csv"
+RELATIVE_PATH = "data-truth/usafacts"
+
+# Download raw data
+cases = pd.read_csv(CONFIRMED_URL, dtype={'countyFIPS': int, 'County Name': str, 'State': str, 'stateFIPS': int}).fillna(value = 'NA')
+cases.to_csv(os.path.join(RELATIVE_PATH,"raw/covid_confirmed_usafacts.csv"), index = False)
+
+deaths = pd.read_csv(DEATHS_URL, dtype={'countyFIPS': int, 'County Name': str, 'State': str, 'stateFIPS': int}).fillna(value = 'NA')
+deaths.to_csv(os.path.join(RELATIVE_PATH,"raw/covid_deaths_usafacts.csv"), index = False)
+
+# Reformat county, state and us data into records of each location-date pair per row
+county_cases = reformat_county_data(cases.copy(deep = True))
+county_deaths = reformat_county_data(deaths.copy(deep = True))
+
+state_cases = reformat_state_data(cases.copy(deep = True))
+state_deaths = reformat_state_data(deaths.copy(deep = True))
+
+us_cases = state_cases.groupby(['date']).sum().reset_index()
+us_cases.insert(loc = 1, column = 'location', value = 'US')
+
+us_deaths = state_deaths.groupby(['date']).sum().reset_index()
+us_deaths.insert(loc = 1, column = 'location', value = 'US')
+
+overall_cases = pd.concat([county_cases, state_cases, us_cases])
+
+overall_deaths = pd.concat([county_deaths, state_deaths, us_deaths])
+
+# Output truth cumulative
+overall_cases.to_csv(os.path.join(RELATIVE_PATH,"truth_usafacts-Cumulative Cases.csv"), columns = ['date', 'location', 'value'], header = ['date', 'location', 'value'], index = False)
+overall_deaths.to_csv(os.path.join(RELATIVE_PATH,"truth_usafacts-Cumulative Deaths.csv"), columns = ['date', 'location', 'value'], header = ['date', 'location', 'value'], index = False)
+
+# Output truth incident
+overall_cases = overall_cases.reset_index()
+overall_cases['diff_cases'] = overall_cases.groupby(by = ['location'])['value'].diff().fillna(overall_cases['value'])
+overall_cases = overall_cases.astype({'diff_cases': int})
+overall_cases.to_csv(os.path.join(RELATIVE_PATH,"truth_usafacts-Incident Cases.csv"), columns = ['date', 'location', 'diff_cases'], header = ['date', 'location', 'value'], index = False)
+
+overall_deaths = overall_deaths.reset_index()
+overall_deaths['diff_cases'] = overall_deaths.groupby(by = ['location'])['value'].diff().fillna(overall_deaths['value'])
+overall_deaths = overall_deaths.astype({'diff_cases': int})
+overall_deaths.to_csv(os.path.join(RELATIVE_PATH,"truth_usafacts-Incident Deaths.csv"), columns = ['date', 'location', 'diff_cases'], header = ['date', 'location', 'value'], index = False)

--- a/travis/update_truth_weekly.sh
+++ b/travis/update_truth_weekly.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+echo "updating truth data..."
+# update truth data
+cd ./data-truth
+
+# update zoltar truth
+python3 ./zoltar-truth-data.py
+
+# upload daily truth
+python3 ./get-truth-data.py
+
+# update nytimes and usa facts
+cd ../
+echo "updating nytimes truth data..."
+python3 ./data-truth/nytimes/nytimes.py
+
+echo "updating usafacts truth data..."
+python3 ./data-truth/usafacts/usafacts.py
+
+# upload truth to zoltar
+echo "Upload truth to Zoltar"
+python3 ./code/zoltar_scripts/upload_truth_to_zoltar.py
+
+# push new truths to github
+echo "Merge detected.. push to github"
+bash ./travis/push-gh.sh


### PR DESCRIPTION
## Description

- Add data-truth/nytimes/nytimes.py script that performs what nytimes.R does
- Add data-truth/usafacts/usafacts.py script that performs what usafacts.R does
- Add travis/update_truth_weekly.sh script that is based off update-truth.sh, adding the command for running the 2 aforementioned script, uploading to truth to zoltar and pushing to github
- Add .github/workflows/update_truth_weekly.yml to create a workflow scheduled at 12pm every sunday 

- Testing: 
- The csv files produced by the two python scripts are compared against the files created by the R script. The contents are identical

Closes #338 