### PR TITLE
Add report shell error to allow script to exit when embedded script e…

### DIFF
--- a/travis/update_truth_weekly.sh
+++ b/travis/update_truth_weekly.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tell bash shell to report errors and exit
+set -e
 
 echo "updating truth data..."
 # update truth data

--- a/travis/upload-to-zoltar.sh
+++ b/travis/upload-to-zoltar.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Tell bash shell to report errors and exit
+set -e
+
 # Automate upload all new forecast to Zoltar
 python3 ./code/zoltar_scripts/upload_covid19_forecasts_to_zoltar.py
 echo "UPLOAD TO ZOLTAR SUCCESSFUL"

--- a/travis/upload_zoltar_master.sh
+++ b/travis/upload_zoltar_master.sh
@@ -1,3 +1,7 @@
+# Tell bash shell to report errors and exit
+set -e
+
+# Re-validate data before uploading
 bash ./travis/validate-data.sh
 
 # Upload to zoltar at every merged pull request


### PR DESCRIPTION
Embedded python script does not trigger outer bash script to fail. The solution is to add "set -e" to tell the shell script to report the error and exit immediately. Solution is suggested from this [post](https://stackoverflow.com/questions/60065135/concourse-pipeline-how-to-have-an-embedded-script-fail-the-pipeline). The solution is tested on another personal repo that replicate the situation

closes #1463 