### PR TITLE
Fix memory issue while building local visualization on Github Actions

### DIFF
--- a/travis/vis-build.sh
+++ b/travis/vis-build.sh
@@ -9,7 +9,7 @@ setup_git() {
 
 commit_website_files() {
   echo "Commiting files..."
-  git add .
+  git add visualization/\*
   git commit --message "Build local visualization: $GITHUB_RUN_NUMBER"
 }
 

--- a/visualization/scripts/parse-data.js
+++ b/visualization/scripts/parse-data.js
@@ -7,6 +7,11 @@ const meta = require('./modules/meta')
 const mmwr = require('mmwr-week')
 const moment = require('moment')
 
+const is_ci = process.env.CI
+// Add a log message when running from Github Actions
+if(is_ci) {
+  console.log("Running parse-data from Github Actions")
+}
 const parseMetadata = (modelDir) => {
   // Return a flusight compatible metadata object
   let rootMetadata = models.getModelMetadata(modelDir)
@@ -76,8 +81,13 @@ modelDirs.forEach(modelDir => {
         let csvTargetDir = path.join('./data', target_cats, modelId)
         fs.ensureDirSync(csvTargetDir)
 
-        // Copy csv
-        fs.copySync(csvFile, path.join(csvTargetDir, info.name))
+        if(is_ci) {
+        // move the csv files instead of copying on CI machines to save memory
+        fs.renameSync(csvFile, path.join(csvTargetDir, info.name))
+        } else {
+          // else we just copy to avoid removal of actual forecast files in local machines
+          fs.copySync(csvFile, path.join(csvTargetDir, info.name))
+        }
 
         // Write metadata
         ensureMetadata(path.join(csvTargetDir, 'meta.yml'), flusightMetadata)


### PR DESCRIPTION
## Description
- Recent builds on Github Actions are failing because the visualization build was copying the _entire_ `data-processed` folder (~ 7GB) inside the `visualization/data` folder and then processing each forecast CSV file to be added to the viz. Hence, the copy was doubling the size of the repository on the CI Build machine which was causing it to run out of memory. 

## Possible fix
- Since the CI does not really use the CSV in the `data-processed` folder, we can move the CSV files to the `data` folder instead of copying. This is the least destructive way I saw to fix the memory issue. 
- We don't want this to happen on our local machines. So added this change for only the case when we run it from Github Actions. 
- When committing the local visualization back, we were adding _all_ unchanged files back. Instead, we only want the local viz changes that live in the `visualization` folder. Therefore, we only add these changes. 

## Test

- Ran this on my local with/without setting the [`CI`](https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables) environment variable which is used to distinguish CI/non-CI runs. 