### PR TITLE
Revert "Fix memory issue while building local visualization on Github Actions"

### DIFF
--- a/travis/vis-build.sh
+++ b/travis/vis-build.sh
@@ -9,7 +9,7 @@ setup_git() {
 
 commit_website_files() {
   echo "Commiting files..."
-  git add visualization/\*
+  git add .
   git commit --message "Build local visualization: $GITHUB_RUN_NUMBER"
 }
 

--- a/visualization/scripts/parse-data.js
+++ b/visualization/scripts/parse-data.js
@@ -7,11 +7,6 @@ const meta = require('./modules/meta')
 const mmwr = require('mmwr-week')
 const moment = require('moment')
 
-const is_ci = process.env.CI
-// Add a log message when running from Github Actions
-if(is_ci) {
-  console.log("Running parse-data from Github Actions")
-}
 const parseMetadata = (modelDir) => {
   // Return a flusight compatible metadata object
   let rootMetadata = models.getModelMetadata(modelDir)
@@ -81,13 +76,8 @@ modelDirs.forEach(modelDir => {
         let csvTargetDir = path.join('./data', target_cats, modelId)
         fs.ensureDirSync(csvTargetDir)
 
-        if(is_ci) {
-        // move the csv files instead of copying on CI machines to save memory
-        fs.renameSync(csvFile, path.join(csvTargetDir, info.name))
-        } else {
-          // else we just copy to avoid removal of actual forecast files in local machines
-          fs.copySync(csvFile, path.join(csvTargetDir, info.name))
-        }
+        // Copy csv
+        fs.copySync(csvFile, path.join(csvTargetDir, info.name))
 
         // Write metadata
         ensureMetadata(path.join(csvTargetDir, 'meta.yml'), flusightMetadata)


### PR DESCRIPTION
Reverts reichlab/covid19-forecast-hub#1856

Some parts of the build code does require data to still be in the data-processed folder, so we may need to fix that before making this change.