### PR TITLE
Fix invalid targets being added to the zoltar truth data

### DIFF
--- a/data-truth/zoltar-truth-data.py
+++ b/data-truth/zoltar-truth-data.py
@@ -63,7 +63,7 @@ def configure_JHU_data(df, target):
         zip(*df_targets['timezero'].map(get_epi_data_TZ))
 
     # truth targets by timezero week
-    df_targets = df_targets[["tz_week", "unit", "target", "value"]]
+    df_targets = df_targets[["tz_year","tz_week", "unit", "target", "value"]]
 
     # Map all timezeros in Zoltar to Corresponding weeks
     df_map_wk_to_tz = pd.DataFrame(columns=['timezero'])
@@ -73,7 +73,7 @@ def configure_JHU_data(df, target):
         zip(*df_map_wk_to_tz['timezero'].map(get_epi_data_TZ))
 
     # Merge timezeros with truth values and targets
-    df_final = pd.merge(df_targets, df_map_wk_to_tz, how='right', on=['tz_week'])
+    df_final = pd.merge(df_targets, df_map_wk_to_tz, how='right', on=['tz_week', 'tz_year'])
 
     # select columns
     df_final = df_final[["timezero", "unit", "target", "value"]]


### PR DESCRIPTION
## Description

This change fixes the addition of invalid Zoltar truth targets to `zoltar-truth.csv`.

## Test
In the screenshot below, you can see that the old truth data was adding `20 wk ahead` targets for timezeros in the future as well. This was because it was doing a merge with only the MMRWeek column instead of the combination of (MMRweek, MMRYear). This change fixes this problem as you see in the screenshot. 
![Screen Shot 2020-11-06 at 10 17 49 AM](https://user-images.githubusercontent.com/3615269/98382951-df721900-2019-11eb-8e84-2f195c9afae0.png)
