### PR TITLE
Handle error when forecast is present on zoltar

### DIFF
--- a/code/zoltar_scripts/upload_covid19_forecasts_to_zoltar.py
+++ b/code/zoltar_scripts/upload_covid19_forecasts_to_zoltar.py
@@ -124,7 +124,7 @@ def upload_covid_forecast_by_model(conn, json_io_dict, forecast_filename, projec
                 return job
         except RuntimeError as err:
             print(f"RuntimeError occured while uploading forecast. Error: {err}")
-            if err is not None and err.args[1]==400:
+            if err.args is not None and len(err.args)>1 and err.args[1].status_code==400:
                 # status code is 400 and we need to rewrite this model.
                 response = err.args[1]
                 if str(json.loads(response.text)["error"]).startswith("A forecast already exists"): 


### PR DESCRIPTION
## Description
This fixes the error in the Zoltar upload job. A nice explanation of the error is present in #1984 . 

## Fix
This can be fixed if we handle the `RuntimeError`. This is how the flow goes: 
- If a `RuntimeError` occurs when `upload_forecast` is called, first check if this error was indeed caused due to an existing forecast was present. Any [such error ](https://github.com/reichlab/covid19-forecast-hub/runs/1385007918?check_suite_focus=true#step:7:2194)text starts with `A forecast already exists..` and the HTTP response code is `400`. Hence, check for this. 
- If true, then delete that forecast on Zoltar using the `zoltpy` util method. 
- Retry the upload of the forecast. 

**PS:** Before this PR is merged, the corresponding zoltpy PR should be merged: https://github.com/reichlab/zoltpy/pull/46 