### PR TITLE
Update metadata file to adhere to schema

### DIFF
--- a/data-processed/AIpert-pwllnod/metadata-AIpert-pwllnod.txt
+++ b/data-processed/AIpert-pwllnod/metadata-AIpert-pwllnod.txt
@@ -2,7 +2,8 @@ team_name: AIpert.org team
 model_name: Piecewise Log Linear of Death
 model_abbr: AIpert-pwllnod
 model_contributors: Quoc Tran (Lead - WalmartLabs) <ttquoc@gmail.com>, Huong Huynh (Virtual Power System) <hthuongsc@gmail.com>, Lam Ho (Dalhousie University-Dept. of Maths and Stats) <lam.ho@dal.ca>
-website_url: https://covid19.aipert.org, https://github.com/QuocTran/COVID-19
+website_url: https://covid19.aipert.org
+repo_url: https://github.com/QuocTran/COVID-19
 license: mit
 team_model_designation: primary
 methods: Piecewise Log Linear of Death using policy change dates


### PR DESCRIPTION
## Description
The `website_url` field had 2 URLs; one was the Github link and the other to the website. The Github URL goes in the `repo_url` section of the metadata instead of `website_url`. Fixing this manually for the metadata file. 

This change is required because builds in the static site generation fail due to improperly formatted URL in the `website_url` field in Zoltar. 