### PR TITLE
Separate update-truth-on-Github with upload-truth-to-Zoltar workflows

### DIFF
--- a/.github/workflows/upload_jhu_truth_to_zoltar_weekly.yml
+++ b/.github/workflows/upload_jhu_truth_to_zoltar_weekly.yml
@@ -1,0 +1,34 @@
+name: Upload JHU truth to Zoltar weekly
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Upload JHU truth to Zoltar weekly'
+  schedule:
+    - cron: '0 18 * * 0'
+
+jobs:
+  upload_zoltar:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.2]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
+    - run: npm install
+    - run: pip3 install -r visualization/requirements.txt
+    - run: python3 code/zoltar_scripts/upload_truth_to_zoltar.py
+      env:
+        Z_USERNAME: ${{ secrets.Z_USERNAME}}
+        Z_PASSWORD: ${{ secrets.Z_PASSWORD}}
+        GH_TOKEN: ${{secrets.GH_TOKEN}}

--- a/travis/update_truth_weekly.sh
+++ b/travis/update_truth_weekly.sh
@@ -20,10 +20,6 @@ python3 ./data-truth/nytimes/nytimes.py
 echo "updating usafacts truth data..."
 python3 ./data-truth/usafacts/usafacts.py
 
-# upload truth to zoltar
-echo "Upload truth to Zoltar"
-python3 ./code/zoltar_scripts/upload_truth_to_zoltar.py
-
 # push new truths to github
 echo "Merge detected.. push to github"
 bash ./travis/push-gh.sh


### PR DESCRIPTION
## Description
---
This change split the weekly truth update workflow into 2 separate workflows: 1 for updating the truth on GitHub, and 1 for uploading it to Zoltar. Making these 2 processes into independent workflows would help avoiding the cases when the failure of one cause the failure of the other, and also provide more flexibility in re-running workflow of our choices

closes #2607
