### PR TITLE
Add logs to check for free space on zoltar upload build

### DIFF
--- a/.github/workflows/upload_to_zoltar.yml
+++ b/.github/workflows/upload_to_zoltar.yml
@@ -15,9 +15,19 @@ jobs:
         node-version: [10.2]
 
     steps:
+    - name: Free disk space
+      run: |
+          df --human-readable
+          sudo apt clean
+          docker rmi $(docker image ls --all --quiet)
+          rm --recursive --force "$AGENT_TOOLSDIRECTORY" 
     - run: sudo apt-get remove ghc-** azure-cli firefox google-cloud-sdk google-chrome-stable hhvm dotnet-sdk-** dotnet-runtime-** moby-** adoptopenjdk-** mongodb-org-** mysql-**
     - run: sudo apt-get autoremove
+    - name: Check space available
+      run: df --human-readable
     - uses: actions/checkout@v2
+    - name: Check space available after checkout
+      run: df --human-readable
     # - name: Use Node.js ${{ matrix.node-version }}
     #   uses: actions/setup-node@v1
     #   with:


### PR DESCRIPTION
## What's there in this PR? 

- Add logs in the Zoltar script to check for free space. This will help using estimating/tracking the free space available.  
- Also added another log to heck for free space after checking out the repository. 