### PR TITLE
Use maximize-build-space for GH action

### DIFF
--- a/.github/workflows/active_update_truth_weekly.yml
+++ b/.github/workflows/active_update_truth_weekly.yml
@@ -17,6 +17,13 @@ jobs:
     steps:
     # - run: sudo apt-get remove ghc-** azure-cli firefox google-cloud-sdk google-chrome-stable hhvm dotnet-sdk-** dotnet-runtime-** moby-** adoptopenjdk-** mongodb-org-** mysql-**
     # - run: sudo apt-get autoremove
+    - name: Free disk space
+      run: |
+          df --human-readable
+          sudo apt clean
+          docker rmi $(docker image ls --all --quiet)
+          rm --recursive --force "$AGENT_TOOLSDIRECTORY"
+          
     - name: Maximize build space
       uses: easimon/maximize-build-space@v4
       with:
@@ -25,6 +32,10 @@ jobs:
         remove-dotnet: 'true'
         remove-android: 'true'
         remove-haskell: 'true'
+        
+    - name: Check space available
+      run: df --human-readable
+      
     - name: Checkout covid19-forecast-hub repo
       uses: actions/checkout@v2
       with:
@@ -81,4 +92,6 @@ jobs:
       working-directory: ./covid19-forecast-hub
       env:
         GH_TOKEN: ${{secrets.GH_TOKEN}}
-      
+        
+    - name: Check space available after update
+      run: df --human-readable

--- a/.github/workflows/active_update_truth_weekly.yml
+++ b/.github/workflows/active_update_truth_weekly.yml
@@ -18,7 +18,7 @@ jobs:
     # - run: sudo apt-get remove ghc-** azure-cli firefox google-cloud-sdk google-chrome-stable hhvm dotnet-sdk-** dotnet-runtime-** moby-** adoptopenjdk-** mongodb-org-** mysql-**
     # - run: sudo apt-get autoremove
     - name: Maximize build space
-      uses: easimon/maximize-build-space@master
+      uses: easimon/maximize-build-space@v4
       with:
         root-reserve-mb: 512
         swap-size-mb: 1024

--- a/.github/workflows/active_update_truth_weekly.yml
+++ b/.github/workflows/active_update_truth_weekly.yml
@@ -15,8 +15,16 @@ jobs:
         node-version: [10.2]
 
     steps:
-    - run: sudo apt-get remove ghc-** azure-cli firefox google-cloud-sdk google-chrome-stable hhvm dotnet-sdk-** dotnet-runtime-** moby-** adoptopenjdk-** mongodb-org-** mysql-**
-    - run: sudo apt-get autoremove
+    # - run: sudo apt-get remove ghc-** azure-cli firefox google-cloud-sdk google-chrome-stable hhvm dotnet-sdk-** dotnet-runtime-** moby-** adoptopenjdk-** mongodb-org-** mysql-**
+    # - run: sudo apt-get autoremove
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@master
+      with:
+        root-reserve-mb: 512
+        swap-size-mb: 1024
+        remove-dotnet: 'true'
+        remove-android: 'true'
+        remove-haskell: 'true'
     - name: Checkout covid19-forecast-hub repo
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/deprecated_update_truth_weekly.yml
+++ b/.github/workflows/deprecated_update_truth_weekly.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Maximize build space
-      uses: easimon/maximize-build-space@master
+      uses: easimon/maximize-build-space@v4
       with:
         root-reserve-mb: 512
         swap-size-mb: 1024

--- a/.github/workflows/deprecated_update_truth_weekly.yml
+++ b/.github/workflows/deprecated_update_truth_weekly.yml
@@ -13,6 +13,14 @@ jobs:
         node-version: [10.2]
 
     steps:
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@master
+      with:
+        root-reserve-mb: 512
+        swap-size-mb: 1024
+        remove-dotnet: 'true'
+        remove-android: 'true'
+        remove-haskell: 'true'
     - uses: actions/checkout@v2
     # - name: Use Node.js ${{ matrix.node-version }}
     #   uses: actions/setup-node@v1

--- a/.github/workflows/upload_to_zoltar.yml
+++ b/.github/workflows/upload_to_zoltar.yml
@@ -17,6 +17,12 @@ jobs:
     steps:
     # - run: sudo apt-get remove ghc-** azure-cli firefox google-cloud-sdk google-chrome-stable hhvm dotnet-sdk-** dotnet-runtime-** moby-** adoptopenjdk-** mongodb-org-** mysql-**
     # - run: sudo apt-get autoremove
+    - name: Free disk space
+      run: |
+          df --human-readable
+          sudo apt clean
+          docker rmi $(docker image ls --all --quiet)
+          rm --recursive --force "$AGENT_TOOLSDIRECTORY" 
     - name: Maximize build space
       uses: easimon/maximize-build-space@v4
       with:
@@ -25,7 +31,11 @@ jobs:
         remove-dotnet: 'true'
         remove-android: 'true'
         remove-haskell: 'true'
+    - name: Check space available
+      run: df --human-readable
     - uses: actions/checkout@v2
+    - name: Check space available after checkout
+      run: df --human-readable
     # - name: Use Node.js ${{ matrix.node-version }}
     #   uses: actions/setup-node@v1
     #   with:

--- a/.github/workflows/upload_to_zoltar.yml
+++ b/.github/workflows/upload_to_zoltar.yml
@@ -15,19 +15,17 @@ jobs:
         node-version: [10.2]
 
     steps:
-    - name: Free disk space
-      run: |
-          df --human-readable
-          sudo apt clean
-          docker rmi $(docker image ls --all --quiet)
-          rm --recursive --force "$AGENT_TOOLSDIRECTORY" 
-    - run: sudo apt-get remove ghc-** azure-cli firefox google-cloud-sdk google-chrome-stable hhvm dotnet-sdk-** dotnet-runtime-** moby-** adoptopenjdk-** mongodb-org-** mysql-**
-    - run: sudo apt-get autoremove
-    - name: Check space available
-      run: df --human-readable
+    # - run: sudo apt-get remove ghc-** azure-cli firefox google-cloud-sdk google-chrome-stable hhvm dotnet-sdk-** dotnet-runtime-** moby-** adoptopenjdk-** mongodb-org-** mysql-**
+    # - run: sudo apt-get autoremove
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@master
+      with:
+        root-reserve-mb: 512
+        swap-size-mb: 1024
+        remove-dotnet: 'true'
+        remove-android: 'true'
+        remove-haskell: 'true'
     - uses: actions/checkout@v2
-    - name: Check space available after checkout
-      run: df --human-readable
     # - name: Use Node.js ${{ matrix.node-version }}
     #   uses: actions/setup-node@v1
     #   with:

--- a/.github/workflows/upload_to_zoltar.yml
+++ b/.github/workflows/upload_to_zoltar.yml
@@ -18,7 +18,7 @@ jobs:
     # - run: sudo apt-get remove ghc-** azure-cli firefox google-cloud-sdk google-chrome-stable hhvm dotnet-sdk-** dotnet-runtime-** moby-** adoptopenjdk-** mongodb-org-** mysql-**
     # - run: sudo apt-get autoremove
     - name: Maximize build space
-      uses: easimon/maximize-build-space@master
+      uses: easimon/maximize-build-space@v4
       with:
         root-reserve-mb: 512
         swap-size-mb: 1024


### PR DESCRIPTION
## Description

Use the market place maximize-build-space github action to free up ~40 GBs of space on GH action virtual environment. Closes #3244 

---
> _If this section does not apply to you, please delete it in your PR_  

If this is a **new team submission**, please include the following details :-  
- Team name: 
- Model Name: 
- Institution:  
---

> _If this section does not apply to you, please delete it in your PR_  

If you are **adding new forecasts** to an existing model, please include the following details:- 
- Team name: 
- Model name that is being updated:  
---

## Checklist

- [ ] Specify a proper PR title with your team name.
- [ ] All validation checks ran successfully on your branch. Instructions to run the tests locally is present [here](https://github.com/reichlab/covid19-forecast-hub/wiki/Running-Checks-Locally).
