### PR TITLE
Remove unneeded storage saving step

### DIFF
--- a/.github/workflows/active_update_truth_weekly.yml
+++ b/.github/workflows/active_update_truth_weekly.yml
@@ -33,12 +33,6 @@ jobs:
         remove-dotnet: 'true'
         remove-android: 'true'
         remove-haskell: 'true'
-
-    - name: remove some additional packages
-      run: sudo apt-get remove ghc-** azure-cli firefox google-cloud-sdk google-chrome-stable hhvm dotnet-sdk-** dotnet-runtime-** moby-** adoptopenjdk-** mongodb-org-** mysql-**
-    
-    - name: autoremove unnecessary dependencies
-      run: sudo apt-get autoremove
         
     - name: Check space available
       run: df --human-readable


### PR DESCRIPTION
## Description

An un-used step in the Truth Upload is causing error. Removing it since it's not needed.

---
> _If this section does not apply to you, please delete it in your PR_  

If this is a **new team submission**, please include the following details :-  
- Team name: 
- Model Name: 
- Institution:  
---

> _If this section does not apply to you, please delete it in your PR_  

If you are **adding new forecasts** to an existing model, please include the following details:- 
- Team name: 
- Model name that is being updated:  
---

## Checklist

- [ ] Specify a proper PR title with your team name.
- [ ] All validation checks ran successfully on your branch. Instructions to run the tests locally is present [here](https://github.com/reichlab/covid19-forecast-hub/wiki/Running-Checks-Locally).
