### PR TITLE
Fix README for using usafacts data

### DIFF
--- a/data-truth/usafacts/README.md
+++ b/data-truth/usafacts/README.md
@@ -2,7 +2,7 @@
 
 To update these data run (in R):
 
-    source("nytimes.R")
+    source("usafacts.R")
     
 This will "copy" the appropriate files from the 
 [USAFacts website](https://usafacts.org/visualizations/coronavirus-covid-19-spread-map/)


### PR DESCRIPTION
It seems that the [README](https://github.com/reichlab/covid19-forecast-hub/blob/master/data-truth/usafacts/README.md) for `usafacts` data is the same as `nytimes` and mentions the incorrect filename (`nytimes.R`) to source when specifying how to obtain the raw data. 

Seemed like a minor fix, but if I'm mistaken feel free to ignore/close the request. Thanks!
