### PR TITLE
Turn off USAFact truth generation in workflow

### DIFF
--- a/.github/workflows/active_update_truth_weekly.yml
+++ b/.github/workflows/active_update_truth_weekly.yml
@@ -78,7 +78,7 @@ jobs:
       run: make recent_data
       working-directory: ./covidData/code/data-processing
       
-    - name: Generate truth csv files (NYTimes, USAFacts, JHU, Hospitalization, Zoltar)
+    - name: Generate truth csv files (NYTimes, JHU, Hospitalization, Zoltar)
       run: Rscript ./covid19-forecast-hub/code/R_scripts/generate_truth_csvs.R
       
     - name: Push Zoltar truth to Zoltar

--- a/code/R_scripts/generate_truth_csvs.R
+++ b/code/R_scripts/generate_truth_csvs.R
@@ -1,7 +1,6 @@
 library(covidData)
 library(covidHubUtils)
 covidHubUtils::preprocess_nytimes("./covid19-forecast-hub/data-truth/nytimes/")
-covidHubUtils::preprocess_usafacts("./covid19-forecast-hub/data-truth/usafacts/")
 covidHubUtils::preprocess_jhu("./covid19-forecast-hub/data-truth/")
 covidHubUtils::preprocess_visualization_truth("./covid19-forecast-hub/visualization/vis-master/covid-csv-tools/dist/truth")
 covidHubUtils::preprocess_hospitalization("./covid19-forecast-hub/data-truth/")


### PR DESCRIPTION
(Note) Keep "USAFact" in the workflow name for simple organizations in GitHub action, but it is not generating USAFact truth data anymore.